### PR TITLE
chore: add armv7 architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       uses: docker/setup-qemu-action@v2.0.0
       with:
         image: tonistiigi/binfmt:qemu-v6.2.0
-        platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+        platforms: "linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x"
 
     - name: Set up Docker Buildx
       id: buildx
@@ -54,6 +54,6 @@ jobs:
       uses: docker/build-push-action@v3.1.0
       with:
         context: .
-        platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+        platforms: "linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x"
         tags: ${{ steps.metadata.outputs.tags }}
         push: true


### PR DESCRIPTION
Added ARMv7 as available architecture in the CI. Next release will contain a new architecture available.

Closes #6

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>